### PR TITLE
Feature/ref arch devops

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,50 @@ Solutions Architecture.
 Check out the [Binbash Leverage Reference Architecture Official Documentation](https://leverage.binbash.com.ar).
 
 
+## Leverage setting
+In order to set Leverage CLI and Vault set the `config/common.config` file as fallows:
+
+```
+# Project (short name)
+project         = "bb"
+
+# Project (long name)
+project_long    = "binbash"
+
+# AWS Region for DR replicatin (required by the backend but also used for other resources)
+region_secondary      = "us-east-2"
+
+# Account IDs
+shared_account_id     = "123456789101"
+
+# Hashicorp Vault private API endpoint
+#
+# If you are on HCP, you can get this from the Admin UI. Otherwise, it will
+# depend on how you set up DNS, TLS and port settings for your self-hosted
+# installation.
+vault_address = "https://bb-le-shared-vault-cluster.private.vault.XXXXXX.aws.hashicorp.cloud:8200"
+
+# Hashicorp Vault token
+#
+# Vault token that will be used by Terraform to perform calls to Vault API.
+# During the initial setup, you will have to use a root token. If you are
+# using a self-hosted installation you will get such token after you initialize
+# Vault; if you are using Hashicorp Cloud Platform you can get the token from
+# HCP Admin UI.
+# After the initial setup, and since we integrate Vault to Github for
+# authentication, you will have to follow these steps:
+#   1- Generate a GitHub Personal Access Token: https://github.com/settings/tokens
+#   2- Click “Generate new token“
+#   3- Under scopes, only select "read:org", under "admin:org"
+#   4- Log in to Vault: vault login -method=github
+#   5- Input the Personal Access Token from the previous step
+#   6- The output should display a Vault token you can use here
+#
+#vault_token = "s.XXXXXXXXXXXXXXXXXXXXXX.Apshc"
+```
+
+**NOTE:** Set `project` and `project_long` and `shared_account_id` variables according to your needs. Also take into account you will need to log in to Vault to generate the the `vault_token` needed in the `config/common.config` file.
+
 ### Ref Links
 
 #### Vault Terraform Provider

--- a/hcp/security-github/main.tf
+++ b/hcp/security-github/main.tf
@@ -20,5 +20,5 @@ resource "vault_github_team" "ref_architecture_admin" {
 resource "vault_github_team" "ref_architecture_dev" {
   backend  = vault_github_auth_backend.organization.id
   team     = "leverage-ref-architecture-aws-dev"
-  policies = ["devs"]
+  policies = ["devops"]
 }


### PR DESCRIPTION
## what
* Add devops policy to the leverage-ref-architecture-aws-dev github team
* Add Leverage CLI instructions for Vault configuration

## why
* To be able to read and modify Vault secrets as devops
* To detail the initial configuration of Leverage CLI & Hashicorp Vault

CC: @diego-ojeda-binbash 
